### PR TITLE
switch from gta controls to fivem key maps

### DIFF
--- a/cl_radar.lua
+++ b/cl_radar.lua
@@ -1804,7 +1804,53 @@ Citizen.CreateThread( function()
 	end 
 end )
 
-function RunControlManager()
+-- Opens the remote control
+RegisterCommand('radar_remote', function()
+	if ( not RADAR:GetKeyLockState() ) then
+		RADAR:OpenRemote()
+	end
+end)
+RegisterKeyMapping("radar_remote", "Open Radar Remote", "keyboard", CONFIG.keyDefaults.remote_control)
+
+-- Locks speed from front antenna
+RegisterCommand('radar_fr_ant', function()
+	if ( not RADAR:GetKeyLockState() ) then
+		RADAR:LockAntennaSpeed( "front" )
+	end
+end)
+RegisterKeyMapping("radar_fr_ant", "Front Antenna Lock", "keyboard", CONFIG.keyDefaults.front_lock)
+
+-- Locks speed from rear antenna
+RegisterCommand('radar_bk_ant', function()
+	if ( not RADAR:GetKeyLockState() ) then
+		RADAR:LockAntennaSpeed( "rear" )
+	end
+end)
+RegisterKeyMapping("radar_bk_ant", "Rear Antenna Lock", "keyboard", CONFIG.keyDefaults.rear_lock)
+
+-- Locks front plate reader
+RegisterCommand('radar_fr_cam', function()
+	if ( not RADAR:GetKeyLockState() ) then
+		READER:LockCam( "front", true, false )
+	end
+end)
+RegisterKeyMapping("radar_fr_cam", "Front Plate Reader Lock", "keyboard", CONFIG.keyDefaults.plate_front_lock)
+
+-- Locks rear plate reader
+RegisterCommand('radar_bk_cam', function()
+	if ( not RADAR:GetKeyLockState() ) then
+		READER:LockCam( "rear", true, false )
+	end
+end)
+RegisterKeyMapping("radar_bk_cam", "Rear Plate Reader Lock", "keyboard", CONFIG.keyDefaults.plate_rear_lock)
+
+-- Toggles the key lock state
+RegisterCommand('radar_key_lock', function()
+	RADAR:ToggleKeyLock()
+end)
+RegisterKeyMapping("radar_key_lock", "Toggle Keybind Lock", "keyboard", CONFIG.keyDefaults.key_lock)
+
+--[[ function RunControlManager()
 	-- Make sure only the keyboard works
 	if ( IsInputDisabled( 0 ) and not IsPauseMenuActive() ) then 
 		if ( not RADAR:GetKeyLockState() ) then 
@@ -1846,16 +1892,16 @@ function RunControlManager()
 			RADAR:ToggleKeyLock()
 		end 
 	end 
-end 
+end  ]]
 
 -- Control manager 
-Citizen.CreateThread( function()
+--[[ Citizen.CreateThread( function()
 	while ( true ) do 
 		RunControlManager()
 
 		Citizen.Wait( 0 )
 	end 
-end )
+end ) ]]
 
 -- Deletes all of the KVPs
 RegisterCommand( "reset_radar_data", function()

--- a/cl_radar.lua
+++ b/cl_radar.lua
@@ -1804,6 +1804,7 @@ Citizen.CreateThread( function()
 	end 
 end )
 
+
 -- Opens the remote control
 RegisterCommand('radar_remote', function()
 	if ( not RADAR:GetKeyLockState() ) then
@@ -1850,58 +1851,6 @@ RegisterCommand('radar_key_lock', function()
 end)
 RegisterKeyMapping("radar_key_lock", "Toggle Keybind Lock", "keyboard", CONFIG.keyDefaults.key_lock)
 
---[[ function RunControlManager()
-	-- Make sure only the keyboard works
-	if ( IsInputDisabled( 0 ) and not IsPauseMenuActive() ) then 
-		if ( not RADAR:GetKeyLockState() ) then 
-			local keyType = RADAR:GetKeybindType()
-
-			-- Opens the remote control 
-			if ( IsDisabledControlJustPressed( 1, CONFIG.keys.remote_control ) ) then 
-				RADAR:OpenRemote()
-			end 
-
-			-- Locks speed from front antenna
-			if ( IsDisabledControlJustPressed( 1, CONFIG.keys[keyType].front_lock ) ) then 
-				RADAR:LockAntennaSpeed( "front" )
-			end 
-
-			-- Locks speed from rear antenna
-			if ( IsDisabledControlJustPressed( 1, CONFIG.keys[keyType].rear_lock ) ) then 
-				RADAR:LockAntennaSpeed( "rear" )
-			end 
-
-			-- Locks front plate reader
-			if ( IsDisabledControlJustPressed( 1, CONFIG.keys[keyType].plate_front_lock ) ) then 
-				READER:LockCam( "front", true, false )
-			end 
-
-			-- Locks front plate reader
-			if ( IsDisabledControlJustPressed( 1, CONFIG.keys[keyType].plate_rear_lock ) ) then 
-				READER:LockCam( "rear", true, false )
-			end 
-
-			-- Toggles between the keybind types
-			if ( IsDisabledControlJustPressed( 1, CONFIG.keys.switch_keys ) ) then 
-				RADAR:ToggleFullKeyboard()
-			end 
-		end 
-		
-		-- Toggles the key lock state 
-		if ( IsDisabledControlJustPressed( 1, CONFIG.keys.key_lock ) ) then 
-			RADAR:ToggleKeyLock()
-		end 
-	end 
-end  ]]
-
--- Control manager 
---[[ Citizen.CreateThread( function()
-	while ( true ) do 
-		RunControlManager()
-
-		Citizen.Wait( 0 )
-	end 
-end ) ]]
 
 -- Deletes all of the KVPs
 RegisterCommand( "reset_radar_data", function()

--- a/config.lua
+++ b/config.lua
@@ -43,58 +43,27 @@ CONFIG.allow_fast_limit = false
 -- open the remote. 
 CONFIG.allow_quick_start_video = true 
 
--- Sets all of the controls
-CONFIG.keys =
+-- Sets the defaults of all keybinds
+-- These keybinds can be changed by each person in their GTA Settings->Keybinds->FiveM
+CONFIG.keyDefaults =
 {
 	-- Remote control key 
-	-- The default key to open the remote control is 166 (F5 - INPUT_SELECT_CHARACTER_MICHAEL)
-	remote_control = 166,
+	remote_control = 'f5',
 
 	-- Radar key lock key 
-	-- The default key to enable/disable the radar key lock is 182 (L - INPUT_CELLPHONE_CAMERA_FOCUS_LOCK)
-	key_lock = 182,
+	key_lock = 'l',
 
-	-- Radar keybinds switch 
-	-- The default key to switch the bind set is (K - INPUT_REPLAY_SHOWHOTKEY)
-	switch_keys = 311, 
+	-- Radar front antenna lock/unlock Key
+	front_lock = 'numpad8',
 
-	-- Keys for a full size keyboard
-	[ "full" ] = {
-		-- Radar front antenna lock/unlock Key 
-		-- The default full keyboard key to lock/unlock the front antenna is 111 (Numpad 8 - INPUT_VEH_FLY_PITCH_UP_ONLY)
-		front_lock = 111,
+	-- Radar rear antenna lock/unlock Key
+	rear_lock = 'numpad5',
 
-		-- Radar rear antenna lock/unlock Key 
-		-- The default full keyboard key to lock/unlock the rear antenna is 112 (Numpad 5 - INPUT_VEH_FLY_PITCH_DOWN_ONLY)
-		rear_lock = 112,
+	-- Plate reader front lock/unlock Key
+	plate_front_lock = 'numpad9',
 
-		-- Plate reader front lock/unlock Key 
-		-- The default full keyboard key to lock/unlock the front plate reader is 118 (Numpad 9 - INPUT_VEH_FLY_SELECT_TARGET_RIGHT)
-		plate_front_lock = 118,
-
-		-- Plate reader rear lock/unlock Key 
-		-- The default full keyboard key to lock/unlock the rear plate reader is 109 (Numpad 6 - INPUT_VEH_FLY_ROLL_RIGHT_ONLY)
-		plate_rear_lock = 109
-	}, 
-
-	-- Keys for smaller keyboards 
-	[ "small" ] = {
-		-- Radar front antenna lock/unlock Key 
-		-- The default small keyboard key to lock/unlock the front antenna is 157 (1 - INPUT_SELECT_WEAPON_UNARMED)
-		front_lock = 157,
-
-		-- Radar rear antenna lock/unlock Key 
-		-- The default small keyboard key to lock/unlock the rear antenna is 158 (2 - INPUT_SELECT_WEAPON_MELEE)
-		rear_lock = 158,
-
-		-- Plate reader front lock/unlock Key 
-		-- The default small keyboard key to lock/unlock the front plate reader is 160 (3 - INPUT_SELECT_WEAPON_SHOTGUN)
-		plate_front_lock = 160,
-
-		-- Plate reader rear lock/unlock Key 
-		-- The default small keyboard key to lock/unlock the rear plate reader is 164 (4 - INPUT_SELECT_WEAPON_HEAVY)
-		plate_rear_lock = 164
-	}
+	-- Plate reader rear lock/unlock Key
+	plate_rear_lock = 'numpad6'
 }
 
 -- Here you can change the default values for the operator menu, do note, if any of these values are not


### PR DESCRIPTION
I believe that switching from the GTA controls to the FiveM keymapping is a beneficial change since you won't be able to activate these keybinds from the controller while also pressing a button on the keyboard.

I've switched to FiveM's keymapping version, which can be seen on their [cookbook](https://cookbook.fivem.net/2020/01/06/using-the-new-console-key-bindings/).

With keymapping, each client is able to change the keybinds themselves, so I have decided to remove the full/small keyboard toggle keybind since you could change these in your settings yourself in this panel:
![image](https://user-images.githubusercontent.com/16978528/77712010-cc7d6d80-6f8f-11ea-951e-69692a5a8993.png)

I have also changed the `config.lua` keys to "keyDefaults" since you are setting the default of each key when the client first loads with the script.

Although I have updated the comments inside the lua files, I have not updated the README.md or any other documentation. If this change is accepted, these documentations will need to be updated.