### PR TITLE
Feature: Bring fast options to top of menu options for ease of access.

### DIFF
--- a/cl_radar.lua
+++ b/cl_radar.lua
@@ -511,8 +511,9 @@ if ( RADAR:IsFastLimitAllowed() ) then
 		end
 
 		-- Add the fast options to the main menu options table
-		table.insert( self.vars.menuOptions, fastOptions[1] )
-		table.insert( self.vars.menuOptions, fastOptions[2] )
+			--PR TrevorBarns: push to front of table, for ease of access.
+		table.insert( self.vars.menuOptions, 1, fastOptions[1] )
+		table.insert( self.vars.menuOptions, 2, fastOptions[2] )
 	end
 
 	-- Returns the numerical fast limit

--- a/cl_radar.lua
+++ b/cl_radar.lua
@@ -511,9 +511,13 @@ if ( RADAR:IsFastLimitAllowed() ) then
 		end
 
 		-- Add the fast options to the main menu options table
-			--PR TrevorBarns: push to front of table, for ease of access.
-		table.insert( self.vars.menuOptions, 1, fastOptions[1] )
-		table.insert( self.vars.menuOptions, 2, fastOptions[2] )
+		if CONFIG.fast_limit_menu_first == true then
+			table.insert( self.vars.menuOptions, 1, fastOptions[2] )	--FasSpd
+			table.insert( self.vars.menuOptions, 2, fastOptions[1] )	--FasLoc
+		else
+			table.insert( self.vars.menuOptions, fastOptions[1] )	--FasLoc
+			table.insert( self.vars.menuOptions, fastOptions[2] )	--FasSpd
+		end
 	end
 
 	-- Returns the numerical fast limit

--- a/config.lua
+++ b/config.lua
@@ -38,6 +38,10 @@ CONFIG = {}
 -- exceeds the fast limit, it will be locked into the fast box. Default setting is disabled to maintain realism
 CONFIG.allow_fast_limit = true
 
+-- Radar fast limit menu order
+-- When enabled, the fast limit options menu will be displayed first followed by fast lock toggle, then all default menu options. 
+CONFIG.fast_limit_menu_first = true
+
 -- Radar only lock players with auto fast locking
 -- When enabled, the radar will only automatically lock a speed if the caught vehicle has a real player in it.
 CONFIG.only_lock_players = false


### PR DESCRIPTION
Currently, when fast options are enabled they are inserted at the back of the menu options table. I find it useful to move to front for ease of changing fast speed on the fly. The PR moves to 1st and 2nd position, however, from a design perspective nesting features, it may make more sense to place in 2nd and 3rd position behind fast display option. 

Menu order before: 
1. **fastDisplay**
2. sameLane sensitivity
3. sameLane sensitivity
4. beep volume
5. voice volume 
6. plate audio
7. units
8. **_fastLock_**
9. **_fastLimit_**

Menu order after:
1. **_fastLock_**
2. **_fastLimit_**
3. **fastDisplay**
4. sameLane sensitivity
5. sameLane sensitivity
6. beep volume
7. voice volume 
8. plate audio
9. units

Optional design that nests features:
1. **fastDisplay**
2. **_fastLock_**
3. **_fastLimit_**
4. sameLane sensitivity
5. sameLane sensitivity
6. beep volume
7. voice volume 
8. plate audio
9. units
