### PR TITLE
[Update] Reset UI Position Button

### DIFF
--- a/nui/radar.css
+++ b/nui/radar.css
@@ -989,21 +989,36 @@ button:focus { outline: none; }
 		position: absolute;
 		left: 0;
 		right: 0;
-		bottom: 30px;
+		bottom: 10px;
 		margin: auto;
 
 		border-radius: 10px;
 		border: none;
 		background-color: rgb( 225, 225, 225 );
 	}
-		#uiSettingsBox .close:hover {
+		#uiSettingsBox .close:hover, #uiSettingsBox .reset:hover {
 			background-color: rgb( 255, 255, 255 );
 		}
 
-		#uiSettingsBox .close:active {
+		#uiSettingsBox .close:active, #uiSettingsBox .reset:active {
 			background-color: rgb( 190, 190, 190 );
 			padding: 0;
 		}
+
+	#uiSettingsBox .reset {
+		width: 140px;
+		height: 20px;
+
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 35px;
+		margin: auto;
+
+		border-radius: 10px;
+		border: none;
+		background-color: rgb( 225, 225, 225 );
+	}
 
 #keyLockLabel {
 	position: absolute;

--- a/nui/radar.html
+++ b/nui/radar.html
@@ -291,15 +291,16 @@
 					<div id="readerIncreaseScale" class="symbol plus"></div>
 				</div>
 			</div>
-			
+
 			<div class="safezone_container">
 				<p>Safezone: <span id="safezoneDisplay">0px</span></p>
 				<input type="range" min="0" max="100" value="0" step="5" class="slider" id="safezone">
 			</div>
+			<button id="resetUiPositions" class="reset">Reset UI Positions</button>
 
 			<button id="closeUiSettings" class="close">CLOSE</button>
 		</div>
-		
+
 		<p id="keyLockLabel">Radar key binds <span id="keyLockStateLabel"></span></p>
 
 		<div id="helpWindow">

--- a/nui/radar.js
+++ b/nui/radar.js
@@ -83,6 +83,7 @@ const elements =
 
 	uiSettingsBtn: $( "#uiSettings" ), 
 	uiSettingsBox: $( "#uiSettingsBox" ), 
+	resetUiBtn: $( "#resetUiPositions" ),
 	closeUiBtn: $( "#closeUiSettings" ),
 	
 	plateReaderBtn: $( "#plateReaderBtn" ), 
@@ -839,6 +840,13 @@ var safezone = 0;
 // Close the UI settings window when the 'Close' button is pressed
 elements.closeUiBtn.click( function() {
 	setEleVisible( elements.uiSettingsBox, false );
+} )
+
+// Reset the UI button positions to 0% 0% incase somehow the UI is oustide the window
+elements.resetUiBtn.click( function() {
+	updatePosition( elements.remote, 0, 0 )
+	updatePosition( elements.radar, 0, 0 )
+	updatePosition( elements.plateReader, 0, 0 )
 } )
 
 // Close the plate reader settings window when the 'Close' button is pressed


### PR DESCRIPTION
Adds a button to the UI Settings to reset the position of the 3 moveable UI locations. I had the issue where my old settings caused my UI positions to be outside my screen window and they couldnt be seen or dragged back onto the screen.