### PR TITLE
Added vehicle blacklist/whitelist

### DIFF
--- a/cl_player.lua
+++ b/cl_player.lua
@@ -140,6 +140,8 @@ Citizen.CreateThread( function()
 			else
 				PLY.vehClassValid = true
 			end
+		else
+			PLY.vehClassValid = false -- set default
 		end
 		Citizen.Wait( 500 )
 	end

--- a/cl_player.lua
+++ b/cl_player.lua
@@ -101,8 +101,46 @@ Citizen.CreateThread( function()
 		PLY.veh = GetVehiclePedIsIn( PLY.ped, false )
 		PLY.inDriverSeat = GetPedInVehicleSeat( PLY.veh, -1 ) == PLY.ped
 		PLY.inPassengerSeat = GetPedInVehicleSeat( PLY.veh, 0 ) == PLY.ped
-		PLY.vehClassValid = GetVehicleClass( PLY.veh ) == 18
 
+		-- Perform check on vehicle and exit if vehicle is not allowed to run radar
+		if CONFIG.useWhitelist == true then
+			-- Check against whitelist
+			local modelHash = GetEntityModel(PLY.veh)
+			local modelName = GetDisplayNameFromVehicleModel(modelHash):lower() -- Convert to lowercase for comparison
+
+			local isWhitelisted = false
+			for _, whitelistedModel in ipairs(CONFIG.vhlWhiteList) do
+				if modelName == whitelistedModel:lower() then
+					isWhitelisted = true
+					PLY.vehClassValid = true
+				end
+			end
+
+			if not isWhitelisted then
+				PLY.vehClassValid = false -- set default
+			end
+
+		elseif (GetVehicleClass(PLY.veh) == 18) then
+			if CONFIG.useBlacklist == true then
+				-- Check against blacklist
+				local modelHash = GetEntityModel(PLY.veh)
+				local modelName = GetDisplayNameFromVehicleModel(modelHash):lower() -- Convert to lowercase for comparison
+				local isBlacklisted = false
+				for _, blacklistedModel in ipairs(CONFIG.vhlBlacklist) do
+					if modelName == blacklistedModel:lower() then
+						isBlacklisted = true
+					end
+				end
+
+				if isBlacklisted then
+					PLY.vehClassValid = false -- set default
+				else
+					PLY.vehClassValid = true
+				end
+			else
+				PLY.vehClassValid = true
+			end
+		end
 		Citizen.Wait( 500 )
 	end
 end )
@@ -114,20 +152,16 @@ Citizen.CreateThread( function()
 		if ( IsPedGettingIntoAVehicle( PLY.ped ) and RADAR:IsPassengerViewAllowed() ) then
 			-- Get the vehicle the player is entering
 			local vehEntering = GetVehiclePedIsEntering( PLY.ped )
+			-- Wait two seconds, this gives enough time for the player to get sat in the seat
+			Citizen.Wait( 2000 )
 
-			-- Only proceed if the vehicle the player is entering is an emergency vehicle
-			if ( GetVehicleClass( vehEntering ) == 18 ) then
-				-- Wait two seconds, this gives enough time for the player to get sat in the seat
-				Citizen.Wait( 2000 )
+			-- Get the vehicle the player is now in
+			local veh = GetVehiclePedIsIn( PLY.ped, false )
 
-				-- Get the vehicle the player is now in
-				local veh = GetVehiclePedIsIn( PLY.ped, false )
-
-				-- Trigger the main sync data function if the vehicle the player is now in is the same as the one they
-				-- began entering
-				if ( veh == vehEntering ) then
-					SYNC:SyncDataOnEnter()
-				end
+			-- Trigger the main sync data function if the vehicle the player is now in is the same as the one they
+			-- began entering
+			if ( veh == vehEntering ) then
+				SYNC:SyncDataOnEnter()
 			end
 		end
 

--- a/config.lua
+++ b/config.lua
@@ -44,7 +44,7 @@ CONFIG.fast_limit_first_in_menu = false
 
 -- Radar only lock players with auto fast locking
 -- When enabled, the radar will only automatically lock a speed if the caught vehicle has a real player in it.
-CONFIG.only_lock_players = false
+CONFIG.only_lock_players = true
 
 -- In-game first time quick start video
 -- When enabled, the player will be asked if they'd like to view the quick start video the first time they
@@ -53,12 +53,12 @@ CONFIG.allow_quick_start_video = true
 
 -- Allow passenger view
 -- When enabled, the front seat passenger will be able to view the radar and plate reader from their end.
-CONFIG.allow_passenger_view = false
+CONFIG.allow_passenger_view = true
 
 -- Allow passenger control
 -- Dependent on CONFIG.allow_passenger_view. When enabled, the front seat passenger will be able to open the
 -- radar remote and control the radar and plate reader for themself and the driver.
-CONFIG.allow_passenger_control = false
+CONFIG.allow_passenger_control = true
 
 -- Set this to true if you use Sonoran CAD with the WraithV2 plugin
 CONFIG.use_sonorancad = false
@@ -113,15 +113,15 @@ CONFIG.menuDefaults =
 
 	-- The speed unit used in conversions
 	-- Options: mph or kmh
-	["speedType"] = "mph",
+	["speedType"] = "kmh",
 
 	-- The state for automatic speed locking. This requires CONFIG.allow_fast_limit to be true.
 	-- Options: true or false
-	["fastLock"] = false,
+	["fastLock"] = true,
 
 	-- The speed limit required for automatic speed locking. This requires CONFIG.allow_fast_limit to be true.
 	-- Options: 0 to 200
-	["fastLimit"] = 60
+	["fastLimit"] = 90
 }
 
 -- Here you can change the default scale of the UI elements, as well as the safezone size
@@ -139,4 +139,22 @@ CONFIG.uiDefaults =
 	-- The safezone size, must be a multiple of 5.
 	-- Options: 0 - 100
 	safezone = 20
+}
+
+-- Do you want only whitelisted vehicles to have the radar?
+-- Bypasses the emergency vehicle check
+CONFIG.useWhiteList = false
+CONFIG.vhlWhiteList =
+{
+	"fbi",
+	"fbi2",
+}
+
+-- Do you want only specific emergency vehicles to have the radar?
+-- Only works if CONFIG.useWhitelist is false
+CONFIG.useBlacklist = true
+CONFIG.vhlBlacklist =
+{
+	"ambulance",
+	"firetruk",
 }

--- a/config.lua
+++ b/config.lua
@@ -44,7 +44,7 @@ CONFIG.fast_limit_first_in_menu = false
 
 -- Radar only lock players with auto fast locking
 -- When enabled, the radar will only automatically lock a speed if the caught vehicle has a real player in it.
-CONFIG.only_lock_players = true
+CONFIG.only_lock_players = false
 
 -- In-game first time quick start video
 -- When enabled, the player will be asked if they'd like to view the quick start video the first time they
@@ -53,12 +53,12 @@ CONFIG.allow_quick_start_video = true
 
 -- Allow passenger view
 -- When enabled, the front seat passenger will be able to view the radar and plate reader from their end.
-CONFIG.allow_passenger_view = true
+CONFIG.allow_passenger_view = false
 
 -- Allow passenger control
 -- Dependent on CONFIG.allow_passenger_view. When enabled, the front seat passenger will be able to open the
 -- radar remote and control the radar and plate reader for themself and the driver.
-CONFIG.allow_passenger_control = true
+CONFIG.allow_passenger_control = false
 
 -- Set this to true if you use Sonoran CAD with the WraithV2 plugin
 CONFIG.use_sonorancad = false
@@ -113,15 +113,15 @@ CONFIG.menuDefaults =
 
 	-- The speed unit used in conversions
 	-- Options: mph or kmh
-	["speedType"] = "kmh",
+	["speedType"] = "mph",
 
 	-- The state for automatic speed locking. This requires CONFIG.allow_fast_limit to be true.
 	-- Options: true or false
-	["fastLock"] = true,
+	["fastLock"] = false,
 
 	-- The speed limit required for automatic speed locking. This requires CONFIG.allow_fast_limit to be true.
 	-- Options: 0 to 200
-	["fastLimit"] = 90
+	["fastLimit"] = 60
 }
 
 -- Here you can change the default scale of the UI elements, as well as the safezone size

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -38,7 +38,7 @@ game "gta5"
 name "Wraith ARS 2X"
 description "Police radar and plate reader system for FiveM"
 author "WolfKnight"
-version "1.3.1"
+version "1.3.2"
 
 -- Include the files
 files {


### PR DESCRIPTION
Added config to whitelist or blacklist vehicles to use the radar.
If whitelist is active, all and only vehicles allowed are those in whitelist. Regardless of their emergency status.
Otherwise, check for emergency category, and, if blacklist is active, check against it.

This logic is done at the same rate of checks as before, so I expect the performance hit to be minimal. None noticed on solo testing.

Changes in 3 files:
fxmanifest.lua - incremented version by 0.0.1
cl_player.lua - added check logic
config.lua - added 4 config statements (2 bools & 2 arrays)